### PR TITLE
Update apt cache before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ $ ansible-galaxy install -r requirements.yml
   * default: "DE"
   * description: 
 
+* **wifi_apt_cache_valid_time**
+  * default: 86400
+  * description: number of seconds APT cache is valid for
+
 ## Example Playbook
 
 Typical playbook run:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 wifi_country: "DE"
-
+wifi_apt_cache_valid_time: 86400

--- a/tasks/wifi.yml
+++ b/tasks/wifi.yml
@@ -7,6 +7,8 @@
     become: yes
     apt:
       name: wpasupplicant
+      update_cache: yes
+      cache_valid_time: "{{ wifi_apt_cache_valid_time }}"
 
   #
   # configure wpa_supplicant


### PR DESCRIPTION
If the APT cache has been cleaned, the package installation will fail as Ansible does not update it by default before an install.